### PR TITLE
Fixed BC option indenting

### DIFF
--- a/pyhyp/__init__.py
+++ b/pyhyp/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 from .pyHyp import pyHyp, pyHypMulti

--- a/pyhyp/pyHyp.py
+++ b/pyhyp/pyHyp.py
@@ -627,7 +627,7 @@ class pyHyp(object):
                         "'yzConst or xzConst'. %s" % helpStr
                     )
 
-                    fBCs[edgeMap[lKey], blkBC - 1] = BCMap[BCToSet]
+                fBCs[edgeMap[lKey], blkBC - 1] = BCMap[BCToSet]
 
         # Set the boundary condition information into fortran
         self.hyp.hypinput.bcs = fBCs


### PR DESCRIPTION
## Purpose
When I was merging the formatting changes from #31 into #33, I inadvertently indented a line that was not supposed to be indented. This broke the BC option. This PR fixes the indenting.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)