### PR TITLE
self.comm is now set in BaseSolver

### DIFF
--- a/pyhyp/__init__.py
+++ b/pyhyp/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 
 from .pyHyp import pyHyp, pyHypMulti

--- a/pyhyp/pyHyp.py
+++ b/pyhyp/pyHyp.py
@@ -384,10 +384,16 @@ class pyHyp(BaseSolver):
         # Set the possible MPI Intracomm
         if comm is None:
             comm = MPI.COMM_WORLD
-        self.comm = comm
 
         # Default options for hyperbolic generation
         defOpts = self._getDefaultOptions()
+
+        # Use supplied options
+        if options is None:
+            raise Error("The options = keyword argument is *NOT* optional. " "It must always be provided")
+
+        # Initialize the inherited BaseSolver
+        super().__init__(name, category, defOpts, options, comm=comm)
 
         # Import and set the hyp module
         curDir = os.path.dirname(os.path.realpath(__file__))
@@ -395,13 +401,6 @@ class pyHyp(BaseSolver):
 
         # Initialize PETSc and MPI if not already done so:
         self.hyp.initpetsc(self.comm.py2f())
-
-        # Use supplied options
-        if options is None:
-            raise Error("The options = keyword argument is *NOT* optional. " "It must always be provided")
-
-        # Initialize the inherited BaseSolver
-        super().__init__(name, category, defOpts, options)
 
         # Set the fortan options
         self._setOptions()

--- a/pyhyp/pyHyp.py
+++ b/pyhyp/pyHyp.py
@@ -380,6 +380,7 @@ class pyHyp(BaseSolver):
 
         name = "pyHyp"
         category = "Hyperbolic mesh generator"
+        informs = {}
 
         # Set the possible MPI Intracomm
         if comm is None:
@@ -393,7 +394,7 @@ class pyHyp(BaseSolver):
             raise Error("The options = keyword argument is *NOT* optional. " "It must always be provided")
 
         # Initialize the inherited BaseSolver
-        super().__init__(name, category, defOpts, options, comm=comm)
+        super().__init__(name, category, defaultOptions=defOpts, options=options, comm=comm, informs=informs)
 
         # Import and set the hyp module
         curDir = os.path.dirname(os.path.realpath(__file__))

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         "numpy>=1.16",
         "mpi4py>=3.0",
-        "mdolab-baseclasses>=1.2",
+        "mdolab-baseclasses>=1.3",
     ],
     classifiers=["Operating System :: Linux", "Programming Language :: Python, Fortran"],
 )


### PR DESCRIPTION
## Purpose
With recent addition of `self.comm` to `BaseSolver` in baseclasses (see https://github.com/mdolab/baseclasses/pull/29) `self.comm` will is overwritten. 
However, PR https://github.com/mdolab/baseclasses/pull/30 now adds self.comm as an argument to BaseSolver making it clear to the user where `self.comm` is set and less error-prone. 
This PR adjusts the code to the above changes.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
