### PR TITLE
Symmetry BC warning and documentation updates

### DIFF
--- a/doc/autoSymm.rst
+++ b/doc/autoSymm.rst
@@ -1,0 +1,23 @@
+.. _pyhyp_autoSymm:
+
+Automatic symmetry BCs
+======================
+
+Using the ``unattachedEdgesAreSymmetry`` option will automatically apply symmetry boundary conditions to any edges that do not interface with another block.
+This page describes how this option works and a rare case where this option can fail.
+
+Automatically applying symmetry boundary conditions involves determining the correct symmetry direction for each unattached edge.
+For a standard case, the magnitudes of the coordinates for all nodes of an unattached edge are summed, and the coordinate direction with the minimum sum is set as the symmetry direction.
+This works because we expect the geometry to lie flat on the symmetry plane.
+However, when an unattached edge is coincident with one of the coordinate axes, this method cannot be used because there will be two directions with a zero sum.
+
+In this case, a secondary check is performed.
+The vectors between nodes on the boundary edge and their adjacent nodes on the first interior edge are computed, and the magnitudes of the coordinates are summed over all vectors.
+The coordinate direction with the maximum sum is taken to be the symmetry direction.
+This assumes that the aforementioned vectors point primarily in the direction normal to the symmetry plane.
+This assumption does not always hold, such as for a highly swept wing.
+If the vectors deviate enough from the normal direction, the symmetry direction will be incorrectly assigned, and the mesh extrusion will fail.
+
+.. warning::
+    
+    If you encounter negative volumes near the symmetry plane, set the symmetry boundary conditions manually using :ref:`the BC option<pyhyp_BC>`.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,22 +9,14 @@
 pyHyp
 =====
 
-Introduction
-============
-
-`pyHyp` is hyperbolic mesh generator that is capable of automatically
-generating two or three dimensional 3D meshes around simple geometric
-configurations. The basic idea is to start with an initial surface (or
-line) corresponding to the geometry of interest and then *grow* or
-*extrude* the mesh in successive layers until it reaches a sufficient
-distance from the original surface. In the process, the entire space
-surrounding the geometry is meshed.
+pyHyp is a hyperbolic mesh generator that automatically generates two or three dimensional meshes around simple geometric configurations.
+The basic idea is to start with an initial surface (or curve) corresponding to the geometry of interest and then *grow* or *extrude* the mesh in successive layers until it reaches a sufficient distance from the original surface.
+In the process, the entire space surrounding the geometry is meshed.
 
 .. _pyhyp_theory:
 
-Most of the theory for `pyHyp` was taken from `Chan and Steger <https://www.sciencedirect.com/science/article/pii/009630039290073A>`_.
-
-
+An overview of the hyperbolic mesh marching method implemented in pyHyp can be found in Section II.A of `Secco et al <https://arc.aiaa.org/doi/pdf/10.2514/1.J059491>`__.
+Most of the theory for pyHyp was taken from `Chan and Steger <https://www.sciencedirect.com/science/article/pii/009630039290073A>`__.
 
 Contents:
 
@@ -33,6 +25,7 @@ Contents:
 
    install
    tutorial
+   autoSymm
    icem
    BC
    options

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -6,7 +6,7 @@ Installation
 Prerequisites
 ------------- 
 
-`pyHyp` depends heavily on other packages to do much of the underlying
+pyHyp depends heavily on other packages to do much of the underlying
 "heavy lifting". The following external components are required for
 pyHyp:
 
@@ -20,14 +20,14 @@ See the MDO Lab installation guide `here <https://mdolab-mach-aero.readthedocs-h
 
 Compilation 
 ------------ 
-``pyHyp`` follows the standard MDO Lab build procedure.
+pyHyp follows the standard MDO Lab build procedure.
 To start, first clone the repo. For stability we recommend checking out a tagged release.
 
 Next, find a configuration file close to your current setup in::
 
     $ config/defaults
 
-and copy it to ''config/config.mk''. For example::
+and copy it to ``config/config.mk``. For example::
 
     $ cp config/defaults/config.LINUX_GFORTRAN_OPENMPI.mk config/config.mk
 
@@ -35,7 +35,7 @@ If you are a beginner user installing the packages on a Linux desktop,
 you should use the ``config.LINUX_GFORTRAN_OPENMPI.mk`` versions of the configuration 
 files. The ``config.LINUX_INTEL.mk`` versions are usually used on clusters.
 
-Once you have copied the config file, compile :ref:`pyHyp` by running::
+Once you have copied the config file, compile pyHyp by running::
 
     $ make
 
@@ -52,14 +52,5 @@ Finally, install the Python interface with::
 Testing Your Installation
 -------------------------
 
-To test your installation, you can run some of the scripts in the `python/examples` folder.
-Some of these require you to have `cgnsUtilities <https://github.com/mdolab/cgnsutilities>`_ installed.
-
-After you run some of the files, you will get a message like this::
-
-  *** The MPI_Attr_get() function was called after MPI_FINALIZE was invoked.
-  *** This is disallowed by the MPI standard.
-  *** Your MPI job will now abort.
-  [MDO-John:7977] Local abort after MPI_FINALIZE completed successfully; not able to aggregate error messages, and not able to guarantee that all other processes were killed!
-  
-Despite its scary look, this is a non-issue and means that the script successfully finished.
+To test your installation, you can run some of the scripts in the ``examples`` folder or run the regression tests with ``testflo -v`` from the root directory.
+Some of the examples require you to have `cgnsUtilities <https://github.com/mdolab/cgnsutilities>`_ installed.

--- a/doc/options.yaml
+++ b/doc/options.yaml
@@ -26,8 +26,8 @@ mode:
 unattachedEdgesAreSymmetry:
   desc: >
     Automatically applies symmetry boundary conditions to any edges that do not interface with another block.
-    This option works in many cases but does not work for all surface meshes.
-    If you encounter negative volumes near the symmetry plane, try explicitly setting the symmetry boundary conditions using the ``BC`` option.
+    This option may fail in rare cases.
+    See :ref:`here<pyhyp_autoSymm>` for details.
 
 outerFaceBC:
   desc: >
@@ -47,7 +47,7 @@ families:
 
 autoConnect:
   desc: >
-    Run cgnsutilities connect function to add any necessary block to block connectivity.
+    Run the cgnsUtilities ``connect`` function to add any necessary block to block connectivity.
 
 noPointReduce:
   desc: >
@@ -100,6 +100,7 @@ splayCornerOrthogonality:
 cornerAngle:
   desc: >
     Maximum convex corner angle in degrees necessary to trigger the implicit node averaging scheme.
+    See Section 8 of :ref:`Chan and Steger<pyhyp_theory>` for more information.
 
 coarsen:
   desc: >
@@ -140,10 +141,9 @@ sourceStrengthFile:
 
 cMax:
   desc: >
-    The maximum permissible ratio of marching direction length to the any other in-plane edge.
+    The maximum permissible ratio of the step in the marching direction to the length of any in-plane edge.
     This parameter effectively operates as a CFL-type limit.
-    If a step would require a step which would result in a ratio ``c`` greater than ``cMax``, the step is automatically split internally to respect this user-supplied limit.
-    Typical values of ``cMax`` are around 6-8.
+    If a step would result in a ratio ``c`` greater than ``cMax``, the step is automatically split internally to respect this user-supplied limit.
     Increased robustness can be achieved at the expense of computational cost by lowering ``cMax``.
 
 nonLinear:
@@ -154,14 +154,14 @@ nonLinear:
 slExp:
   desc: >
     Exponent for the :math:`S_l` computation.
-    The :math:`S_l` value serves the same purpose as found in Chan et al. but the computation is different.
+    The :math:`S_l` value serves the same purpose as found in Section 6 of :ref:`Chan and Steger<pyhyp_theory>`, but the computation is different.
     The :math:`S_l` computation in Chan is given as :math:`\sqrt{\frac{N-1}{l-1}}` for :math:`l > 2`.
 
 ps0:
   desc: >
     Initial pseudo off-wall spacing.
     This spacing **must** be less than or equal to ``s0``.
-    This is actual spacing the hyperbolic scheme uses.
+    This is the actual spacing the hyperbolic scheme uses.
     The solver may take many pseudo steps before the first real grid level at ``s0``.
     This is computed internally if a non-positive value is provided.
 
@@ -176,42 +176,44 @@ pGridRatio:
 epsE:
   desc: >
     The explicit smoothing parameter.
-    See the :ref:`Theory<pyhyp_theory>` section for more information.
-    Typical values are approximately 1.0. Increasing the explicit smoothing may result in a smoother grid, at the expense of orthogonality.
-    If the geometry is very sharp corners, too much explicit smoothing will cause the solver to rapidly "soften" the corner and the grid will fold back on itself.
+    Typical values are approximately 1.0.
+    Increasing the explicit smoothing may result in a smoother grid, at the expense of orthogonality.
+    If the geometry has very sharp corners, too much explicit smoothing will cause the solver to rapidly "soften" the corner and the grid will fold back on itself.
     In concave corners, additional smoothing will prevent lines from crossing (avoiding negative cells).
+    See Section 3 of :ref:`Chan and Steger<pyhyp_theory>` for more information.
 
 epsI:
   desc: >
     Implicit smoothing parameter.
-    See the :ref:`Theory<pyhyp_theory>` section for more information.
     Typical values are from 2.0 to 6.0.
     Generally increasing the implicit coefficient results in a more stable solution procedure.
     Usually this value should be twice the explicit smoothing parameter.
+    See Section 3 of :ref:`Chan and Steger<pyhyp_theory>` for more information.
 
 theta:
   desc: >
-    Kinsley-Barth coefficient See the :ref:`Theory<pyhyp_theory>` section for more information.
-    Only a single theta value is used for both directions.
+    Kinsey-Barth coefficient.
+    This provides additional implicit smoothing.
+    A single theta value is used for both in-plane directions.
     Typical values are ~2.0 to ~4.0.
+    See Section 3 of :ref:`Chan and Steger<pyhyp_theory>` for more information.
 
 volCoef:
   desc: >
     Coefficient used in point-Jacobi local volume smoothing algorithm.
-    Typically this value is 0.16 and need not be modified.
+    Typically this value does not need to be modified.
     Use more ``volSmoothIter`` for stronger local smoothing.
+    See Section 5 of :ref:`Chan and Steger<pyhyp_theory>` for more information.
 
 volBlend:
   desc: >
     The global volume blending coefficient.
-    See the :ref:`Theory<pyhyp_theory>` section for more information.
-    This value will typically be very small, especially if you widely varying cell sizes.
+    This value will typically be very small, especially if you have widely varying cell sizes.
     Typical values are from ~0 to 0.001.
 
 volSmoothIter:
   desc: >
     The number of point-Jacobi local volume smoothing iterations to perform.
-    Typical values are ~5 to ~25.
 
 volSmoothSchedule:
   desc: >
@@ -230,7 +232,7 @@ KSPMaxIts:
 
 KSPSubspaceSize:
   desc: >
-    Size of the ksp subspace.
+    Size of the Krylov subspace.
     Very large and difficult problems may benefit from a larger subspace size.
 
 writeMetrics:

--- a/src/3D/setup3d.F90
+++ b/src/3D/setup3d.F90
@@ -540,6 +540,13 @@ subroutine setup(fileName, fileType)
                     if (((xSum(mod(i, 3)+1) - xSum(i)) < 1.e-10) .or. &
                         ((xSum(mod(i+1, 3)+1) - xSum(i)) < 1.e-10)) then
 
+                      print *, ""
+                      print *, "WARNING: 'unattachedEdgesAreSymmetry' may fail when an"
+                      print *, "edge is coincident with a coordinate axis. Set the"
+                      print *, "symmetry BCs manually with the 'BC' option if you"
+                      print *, "encounter negative volumes near the symmetry plane."
+                      print *, ""
+
                       ! Get the row of coordinates one inboard from the edge of the patch.
                       select case(iEdge)
                       case (iLow)
@@ -567,7 +574,7 @@ subroutine setup(fileName, fileType)
                     ! Set the symmetry plane BCs according to which coordinate
                     ! index corresponded to the edge coordinates being 0.
                     if (i== 1) then
-                       BCs(iEdge, ii) = BCXsymm
+                       BCs(iEdge, ii) = BCXSymm
                     else if(i==2) then
                        BCs(iEdge, ii) = BCYSymm
                     else if(i==3) then


### PR DESCRIPTION
## Purpose
This closes #26 by documenting how `unattachedEdgesAreSymmetry` works and adding a warning in Fortran when the automatic symmetry BC assignment could fail.

This also closes #25 by adding references to specific sections of Chan and Steger in the options descriptions. I fixed the broken link to the "Theory section" in an earlier PR. I think with this slight cleanup and the reference to the Secco 2021 paper (which provides a clear description of the method), the issue can be closed.

I made some other minor edits to the docs. These were mostly fixing typos or removing outdated information.


## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
