### PR TITLE
Update Fortran Standard to 2008

### DIFF
--- a/config/defaults/config.LINUX_GFORTRAN_OPENMPI.mk
+++ b/config/defaults/config.LINUX_GFORTRAN_OPENMPI.mk
@@ -21,7 +21,7 @@ CGNS_LINKER_FLAGS=-L$(CGNS_HOME)/lib -lcgns
 FF90_GEN_FLAGS = -fPIC -std=f2008
 CC_GEN_FLAGS   = -fPIC
 
-FF90_OPT_FLAGS   =  -fPIC -fdefault-real-8 -O2 -std=f2008
+FF90_OPT_FLAGS   = -fdefault-real-8 -O2
 CC_OPT_FLAGS     = -O2
 
 # ------- Define Linker Flags ------------------------------------------

--- a/config/defaults/config.LINUX_GFORTRAN_OPENMPI.mk
+++ b/config/defaults/config.LINUX_GFORTRAN_OPENMPI.mk
@@ -18,10 +18,10 @@ CGNS_INCLUDE_FLAGS=-I$(CGNS_HOME)/include
 CGNS_LINKER_FLAGS=-L$(CGNS_HOME)/lib -lcgns
 
 # ------- Define Compiler Flags ----------------------------------------
-FF90_GEN_FLAGS = -fPIC
+FF90_GEN_FLAGS = -fPIC -std=f2008
 CC_GEN_FLAGS   = -fPIC
 
-FF90_OPT_FLAGS   =  -fPIC -fdefault-real-8 -O2
+FF90_OPT_FLAGS   =  -fPIC -fdefault-real-8 -O2 -std=f2008
 CC_OPT_FLAGS     = -O2
 
 # ------- Define Linker Flags ------------------------------------------

--- a/config/defaults/config.LINUX_INTEL_OPENMPI.mk
+++ b/config/defaults/config.LINUX_INTEL_OPENMPI.mk
@@ -17,10 +17,10 @@ CGNS_INCLUDE_FLAGS=-I$(CGNS_HOME)/include
 CGNS_LINKER_FLAGS=-L$(CGNS_HOME)/lib -lcgns
 
 # ------- Define Compiler Flags ----------------------------------------
-FF90_GEN_FLAGS = -fPIC
+FF90_GEN_FLAGS = -fPIC -stand f08
 CC_GEN_FLAGS   = -fPIC
 
-FF90_OPT_FLAGS   =  -fPIC -r8 -O2
+FF90_OPT_FLAGS   =  -fPIC -r8 -O2 -stand f08
 CC_OPT_FLAGS     = -O2
 
 # ------- Define Linker Flags ------------------------------------------

--- a/config/defaults/config.LINUX_INTEL_OPENMPI.mk
+++ b/config/defaults/config.LINUX_INTEL_OPENMPI.mk
@@ -20,7 +20,7 @@ CGNS_LINKER_FLAGS=-L$(CGNS_HOME)/lib -lcgns
 FF90_GEN_FLAGS = -fPIC -stand f08
 CC_GEN_FLAGS   = -fPIC
 
-FF90_OPT_FLAGS   =  -fPIC -r8 -O2 -stand f08
+FF90_OPT_FLAGS   = -r8 -O2
 CC_OPT_FLAGS     = -O2
 
 # ------- Define Linker Flags ------------------------------------------

--- a/src/3D/3D_elliptic.F90
+++ b/src/3D/3D_elliptic.F90
@@ -60,7 +60,7 @@ subroutine runElliptic
   integer(kind=intType) :: istart, iend, inds(3)
 
   integer(kind=intType) ::  cg, nzones, zone, zoneSize(9), s, F, base, k
-  character*32 :: zonename
+  character(len=32) :: zonename
   logical :: successful
   real(kind=realType), dimension(:, :, :), allocatable  :: coorX, coorY, coorZ, valPhi, vX, vY, vZ
   real(kind=realType) :: pt(3), V(3), phi, times(2)
@@ -1180,7 +1180,7 @@ subroutine setupPanels
   ! grid levels: Because of the MG approach we can know exactly how
   ! many panels we be on each level:
   if (myid == 0) then
-     write(*, "(a,I2,a,I6,a)"), 'Level ',1, ' has ',nPglobal, ' panels'
+     write(*, "(a,I2,a,I6,a)") 'Level ',1, ' has ',nPglobal, ' panels'
   end if
 
   MGLoop: do iLevel = 2, levelMax
@@ -1203,7 +1203,7 @@ subroutine setupPanels
         ii = ii + sizes(1)*sizes(2)
      end do
      if (myid == 0) then
-        write(*, "(a,I2,a,I6,a)"), 'Level ',iLevel, ' has ',ii, ' panels'
+        write(*, "(a,I2,a,I6,a)") 'Level ',iLevel, ' has ',ii, ' panels'
      end if
      ! Now allocate this level
      allocate(MGP(iLevel)%panels(ii))

--- a/src/3D/3D_utilities.F90
+++ b/src/3D/3D_utilities.F90
@@ -295,7 +295,7 @@ subroutine writeIteration
   if (myid == 0) then
 
      ! Iteration Count
-     write(*,"(i7,x)",advance="no") marchIter
+     write(*,"(i7,1x)",advance="no") marchIter
 
      ! CPU time
      write(*,"(f6.1,1x)",advance="no") dble(mpi_wtime()) - timeStart

--- a/src/3D/readCGNS.F90
+++ b/src/3D/readCGNS.F90
@@ -19,7 +19,7 @@ subroutine readCGNS(cgnsFile)
   integer(kind=intType) :: dummybocoType, DirichletFlag, NeumannFlag
   integer(kind=cgsize_t) :: dims(6)
   real(kind=realType), dimension(:, :), allocatable :: coor
-  character*32 :: baseName, zoneName, bocoName, DatasetName
+  character(len=32) :: baseName, zoneName, bocoName, DatasetName
 
   if (myid == 0) then
      ! Open and get the number of zones:
@@ -133,7 +133,7 @@ subroutine readFamily(cgnsFile, iBlock, family, foundFam)
   ! Input/Output Arguments
   character*(*),intent(in) :: cgnsFile
   integer(kind=intType), intent(in) :: iBlock
-  character*32,intent(out) :: family
+  character(len=32),intent(out) :: family
   logical, intent(out) :: foundFam
 
   ! Working
@@ -143,7 +143,7 @@ subroutine readFamily(cgnsFile, iBlock, family, foundFam)
   integer(kind=intType) :: NormalIndex(3), NormalDataType, ndataset
   integer(kind=intType) :: ptset_type,  normalList
   integer(cgsize_t) :: pts(2,2), npnts, NormalListSize
-  character*32 :: zoneName, bocoName
+  character(len=32) :: zoneName, bocoName
 
   family = ""
   call cg_open_f(trim(cgnsFile), CG_MODE_READ, cg, ierr)

--- a/src/3D/smoothing.F90
+++ b/src/3D/smoothing.F90
@@ -262,8 +262,8 @@ subroutine freezeFaces(blockIDs, nBlockIDs, dstar)
   implicit none
 
   ! Input Parameters
-  integer (kind=intType), intent(in), dimension(nBlockIDs) :: blockIDs
   integer(kind=intType), intent(in) :: nBLockIDs
+  integer (kind=intType), intent(in), dimension(nBlockIDs) :: blockIDs
   real(kind=realType), intent(in) :: dstar
 
   ! Working

--- a/src/3D/writeCGNS.F90
+++ b/src/3D/writeCGNS.F90
@@ -29,14 +29,14 @@ subroutine writeCGNS(fileName)
   ! Working Variables
   integer(kind=intType) :: cg, ierr, iEdge, il, jl
   integer(kind=intType) :: cellDim, physDim, base, coordID, gridShp(3)
-  character*256 :: zoneName, bcName
+  character(len=256) :: zoneName, bcName
   integer(kind=intType) :: zone, ii, i, j, k, cgtransform(3)
   integer(cgsize_t) :: sizes(9), ptRange(3,2)
   integer(kind=intType) ::  fullRange(3,2), iBoco
   integer(kind=intType) :: s, f
   real(kind=realType), dimension(:,:,:), allocatable :: coordArray, solArray
-  character*12, dimension(3) :: coorNames, r_ksi, r_eta, r_zeta
-  character*12, dimension(3) :: r_ksi_ksi, r_eta_eta, diss
+  character(len=12), dimension(3) :: coorNames, r_ksi, r_eta, r_zeta
+  character(len=12), dimension(3) :: r_ksi_ksi, r_eta_eta, diss
   integer(kind=intType) :: iPatch, idim, idglobal
   real(kind=realType), pointer, dimension(:) :: xxtmp
 
@@ -207,7 +207,7 @@ subroutine writeCGNS(fileName)
 contains
   subroutine writeVar(vectors, names)
     Vec, dimension(:) :: vectors
-    character*12, dimension(3) :: names
+    character(len=12), dimension(3) :: names
 
     do idim=1,3
        do k=1,N
@@ -250,7 +250,7 @@ contains
     if (myid == 0) then
 998    FORMAT('boco.',I5.5)
        iBoco = iBoco + 1
-       write (bcName, 998), iBoco
+       write (bcName, 998) iBoco
 
        call cg_boco_write_f(cg, base, iPatch, trim(bcName), &
             BCType, PointRange, 2_cgsize_t, ptRange, BCout, ierr)

--- a/src/3D/writeLayer.F90
+++ b/src/3D/writeLayer.F90
@@ -65,7 +65,7 @@ subroutine writeLayerPlot3d(fileName, layer)
         do idim=1,3
            do j=1, patches(iPatch)%jl
               do i=1, patches(iPatch)%il
-                 write(7,7), patches(ii)%X(idim, i, j)
+                 write(7,7) patches(ii)%X(idim, i, j)
               end do
            end do
         end do
@@ -116,7 +116,7 @@ subroutine writeLayerFE(fileName, layer, partitions)
 102  format(g20.12, g20.12, g20.12, g20.12)
 103  format(I6,I6,I6,I6)
 
-     write(7, 101), nxGlobal, faceTotal
+     write(7, 101) nxGlobal, faceTotal
      do i=1,nxGlobal
         write(7, 102) xx(3*i-2), xx(3*i-1), xx(3*i)
      end do

--- a/src/3D/writePlot3d.F90
+++ b/src/3D/writePlot3d.F90
@@ -54,7 +54,7 @@ subroutine writePlot3d(fileName)
                  do i=1, patches(iPatch)%il
                     ! We will use l_index to get the correct pointer into grid3D
                     idGlobal = patches(iPatch)%l_index(i, j)
-                    write(7,7), xx(3*(idGlobal-1)+iDim)
+                    write(7,7) xx(3*(idGlobal-1)+iDim)
                  end do
               end do
               call VecRestoreArrayF90(XLocal, xx, ierr)

--- a/src/modules/bspline.f90
+++ b/src/modules/bspline.f90
@@ -19,9 +19,9 @@ contains
 
     ! Input/Output
     type(surfType), intent(in) :: surf
+    integer(kind=intType), intent(in):: n
     real(kind=realType), intent(in), dimension(n) :: u, v
     real(kind=realType), intent(out), dimension(3, n) :: pts
-    integer(kind=intType), intent(in):: n
     ! Working
     integer(kind=intType) :: ileftu, ileftv, istartu, istartv, ii, i, j, idim
     real(kind=realType) :: basisu(surf%ku)
@@ -127,8 +127,8 @@ contains
     implicit none
 
     ! Input
-    real(kind=realType), intent(in)  :: t(nctl+k), u
     integer(kind=intType), intent(in)  :: nctl, k, ind
+    real(kind=realType), intent(in)  :: t(nctl+k), u
 
     ! Output
     real(kind=realType), intent(out) :: B(0:k-1)


### PR DESCRIPTION
## Purpose
Update the Fortran standard to 2008. I picked 2008 because this datbase relies on [norm2](https://gcc.gnu.org/onlinedocs/gfortran/NORM2.html), which comes from the 2008 standard.

## Type of change
What types of change is it?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [X] Maintenance update
- [ ] Other (please describe)

## Testing
I have not tested this with TAPENADE. I also don't think I currently have any access to intel compiler, so I cannot check the intel flags or compilation. (I guess we probably have a docker image I can try?)

## Checklist

- [X] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [X] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
