### PR TITLE
Update setup.py with allowed numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     ),
     package_data={"pyhyp": ["*.so"]},
     install_requires=[
-        "numpy>=1.16,<1.24",
+        "numpy>=1.16,!=1.24,!=1.24.1,!=1.24.2",
         "mpi4py>=3.0",
         "mdolab-baseclasses>=1.3",
         "cgnsutilities>=2.5",


### PR DESCRIPTION
## Purpose
Numpy just released 1.24.3, so issues described in #69 should be addressed. The `setup.py` now excludes the problematic 1.24 versions, but should permit everything above 1.16. If we know of other versions, we should add them also.

Closes #69 

## Expected time until merged
No rush.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
