### PR TITLE
Mesh check error printout

### DIFF
--- a/src/3D/setup3d.F90
+++ b/src/3D/setup3d.F90
@@ -43,6 +43,7 @@ subroutine setup(fileName, fileType)
     integer(kind=intType) :: i, j, k, ii, jj, iii, jjj, ierr, iStart, iEnd
     integer(kind=intType) :: isize, ind, icell, idim, BCToSet, il, jl, iEdge, iBCToSet
     logical :: found
+    ! logical :: error
     character(5) :: faceStr
     integer(kind=intType), dimension(:), pointer :: lPtr1, lPtr2
     real(kind=realType), dimension(:, :), pointer :: xPtr, xPtrRowInward
@@ -891,12 +892,14 @@ subroutine setup(fileName, fileType)
             print *, 'Corner averaging activated for ', nAverage, ' nodes.'
         end if
 
+        ! error = .False.
+        
         ! Do a sanity check to make sure that all nodes have their
         ! fullnPtr populated.
         do i = 1, nUnique
             if (fullNPtr(1, i) == 0) then
-                print *, 'There was a general error with topology computation for node:', uniquePts(:, i)
-                stop
+                print *, 'aaaaa There was a general error with topology computation for node:', uniquePts(:, i)
+                ! error = .True.
             end if
         end do
 
@@ -905,16 +908,19 @@ subroutine setup(fileName, fileType)
         ! their fullnPtr populated.
         do i = 1, nUnique
             if (fullTopoType(i) == topoEdge .and. fullBCType(1, i) == BCDefault) then
-                print *, 'There was a missing boundary condition for edge node:', uniquePts(:, i)
-                stop
-
+                print *, 'bbbbb There was a missing boundary condition for edge node:', uniquePts(:, i)
+                ! error = .True.
+                
             else if (fullTopoType(i) == topoCorner .and. (fullBCType(1, i) == BCDefault .or. &
                                                           fullBCType(2, i) == BCDefault)) then
-                print *, 'There was a missing boundary condition for corner node:', uniquePts(:, i)
-                stop
+                print *, 'ccccc There was a missing boundary condition for corner node:', uniquePts(:, i)
+                ! error = .True.
             end if
-
         end do
+
+        ! if (error == .True.) then
+        !     stop
+        ! end if
 
         ! Free up some more memory
         deallocate (nte, ntePtr, directedNodeConn, nodeConn, nEdge, nDirectedEdge)


### PR DESCRIPTION
## Purpose
This changes the logic for error printouts for boundary condition checks and topology errors so all errors present in the mesh will print out. The previous behavior was to exit on the first issue, making it hard to fix multiple errors at once.

## Expected time until merged
None

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Run this with a broken mesh to see if all expected errors are printed out

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [x] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
