### PR TITLE
Updating MExt to support python 3.12 syntax

### DIFF
--- a/pyhyp/MExt.py
+++ b/pyhyp/MExt.py
@@ -1,27 +1,28 @@
 import tempfile
-import imp
+from importlib.util import find_spec
+from pathlib import Path
 import os
 import shutil
 import sys
 
 
-def _tmp_pkg(dirName):
+def _tmp_pkg(tempDir):
     """
     Create a temporary package.
 
     Returns (name, path)
     """
     while True:
-        path = tempfile.mkdtemp(dir=dirName)
+        path = tempfile.mkdtemp(dir=tempDir)
         name = os.path.basename(path)
-        try:
-            imp.find_module(name)
-            # if name is found, delete and try again
-            os.rmdir(path)
-        except Exception:  # noqa: E722
+        spec = find_spec(name)
+        # None means the name was not found
+        if spec is None:
             break
-    init = open(os.path.join(path, "__init__.py"), "w")
-    init.close()
+        # if name is found, delete and try again
+        os.rmdir(path)
+    # this creates an init file so that python recognizes this as a package
+    Path(os.path.join(path, "__init__.py")).touch()
     return name, path
 
 
@@ -30,12 +31,13 @@ class MExt(object):
     Load a unique copy of a module that can be treated as a "class instance".
     """
 
-    def __init__(self, name, path=None, debug=False):
+    def __init__(self, libName, packageName, debug=False):
         tmpdir = tempfile.gettempdir()
-        self.name = name
+        self.name = libName
         self.debug = debug
         # first find the "real" module on the "real" syspath
-        srcfile, srcpath, srcdesc = imp.find_module(name, path)
+        spec = find_spec(packageName)
+        srcpath = os.path.join(spec.submodule_search_locations[0], f"{libName}.so")
         # now create a temp directory for the bogus package
         self._pkgname, self._pkgdir = _tmp_pkg(tmpdir)
         # copy the original module to the new package

--- a/pyhyp/pyHyp.py
+++ b/pyhyp/pyHyp.py
@@ -409,8 +409,8 @@ class pyHyp(BaseSolver):
         super().__init__(name, category, defaultOptions=defOpts, options=options, comm=comm, informs=informs)
 
         # Import and set the hyp module
-        curDir = os.path.dirname(os.path.realpath(__file__))
-        self.hyp = MExt.MExt("hyp", [curDir], debug=debug)._module
+        curDir = os.path.basename(os.path.dirname(os.path.realpath(__file__)))
+        self.hyp = MExt.MExt("hyp", curDir, debug=debug)._module
 
         # Initialize PETSc and MPI if not already done so:
         self.hyp.initpetsc(self.comm.py2f())


### PR DESCRIPTION
## Purpose
Per title.

## Expected time until merged
Once tests pass.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
We currently dont run or test python 3.12, but if anyone has it installed, please test.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
